### PR TITLE
Fix first install where package can't be hold. (#21)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,12 @@
 ---
 galaxy_info:
+  namespace: bimdata
   role_name: fluentbit
   author: Romain
   description: This role installs and configures Fluentbit.
   company: BIMData.io
   license: MIT
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.13"
   platforms:
     - name: Debian
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,23 +21,11 @@
     filename: fluentbit
     state: present
 
-- name: "Get installed Fluentbit version."
-  command: dpkg-query --showformat='${Version}' --show {{ fluentbit_pkg_name }}
-  register: fluentbit_pkg_installed_version
-  failed_when: false
-  changed_when: false
-  check_mode: false
-
-- name: "Unhold Fluentbit version."
-  dpkg_selections:
-    name: "{{ fluentbit_pkg_name }}"
-    selection: install
-  when: not fluentbit_pkg_version_hold or (fluentbit_pkg_installed_version.stdout and fluentbit_pkg_installed_version.stdout != fluentbit_pkg_version)
-
 - name: "Install Fluentbit."
   apt:
     name: "{{ fluentbit_pkg_name }}{% if fluentbit_pkg_version is defined and fluentbit_pkg_version != '' %}={{ fluentbit_pkg_version }}{% endif %}"
     update_cache: true
+    allow_change_held_packages: true
     state: present
   notify: "Restart Fluentbit."
 


### PR DESCRIPTION
* Fix first install where package can't be hold.

It's also cleaner to not unhold a package. In case of failure during the install, the package could be un-hold and upgrade to the wrong version by something else for example. Fix #20

* Fix min ansible version to use allow_change_held_packages.